### PR TITLE
Handle CRLF credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/meschansky/go-pia
 
-go 1.24.1
+go 1.23

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/meschansky/go-pia
 
-go 1.23
+go 1.24.1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,17 +168,21 @@ func splitLines(s string) []string {
 	var line string
 
 	for _, r := range s {
-		if r == '\n' {
+		switch r {
+		case '\r':
+			// ignore carriage returns to support Windows line endings
+			continue
+		case '\n':
 			lines = append(lines, line)
 			line = ""
-		} else {
+		default:
 			line += string(r)
 		}
 	}
 
 	// Add the last line if there's any content or if the string ended with a newline
 	// and we've already added all previous content
-	if line != "" || (len(s) > 0 && s[len(s)-1] == '\n') {
+	if line != "" || (len(s) > 0 && (s[len(s)-1] == '\n' || s[len(s)-1] == '\r')) {
 		lines = append(lines, line)
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -199,6 +199,10 @@ func TestSplitLines(t *testing.T) {
 			input:    "line_with_trailing_newline\n",
 			expected: []string{"line_with_trailing_newline", ""},
 		},
+		{
+			input:    "line1\r\nline2\r\n",
+			expected: []string{"line1", "line2", ""},
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
## Summary
- fix Windows CRLF support in `splitLines`
- add unit test covering CRLF lines

## Testing
- `go test ./...`
